### PR TITLE
Add process id field to trace events

### DIFF
--- a/fuseline/tracing.py
+++ b/fuseline/tracing.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
-
 import os
+import socket
+from datetime import datetime
 
 from .interfaces import Tracer
 
@@ -34,4 +34,5 @@ class BoundTracer(Tracer):
         event.setdefault("workflow_id", self.workflow_id)
         event.setdefault("workflow_instance_id", self.instance_id)
         event.setdefault("process_id", os.getpid())
+        event.setdefault("host_id", socket.gethostname())
         self.tracer.record(event)

--- a/fuseline/tracing.py
+++ b/fuseline/tracing.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from datetime import datetime
 
+import os
+
 from .interfaces import Tracer
 
 
@@ -31,4 +33,5 @@ class BoundTracer(Tracer):
     def record(self, event: dict) -> None:
         event.setdefault("workflow_id", self.workflow_id)
         event.setdefault("workflow_instance_id", self.instance_id)
+        event.setdefault("process_id", os.getpid())
         self.tracer.record(event)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -39,6 +39,7 @@ def test_examples(name: str, expected: Iterable[str], capsys: pytest.CaptureFixt
         assert trace_file.exists()
         entries = [json.loads(line) for line in trace_file.read_text().splitlines()]
         assert [e["event"] for e in entries][:2] == ["workflow_started", "step_enqueued"]
+        assert "process_id" in entries[0]
         trace_file.unlink()
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -40,6 +40,7 @@ def test_examples(name: str, expected: Iterable[str], capsys: pytest.CaptureFixt
         entries = [json.loads(line) for line in trace_file.read_text().splitlines()]
         assert [e["event"] for e in entries][:2] == ["workflow_started", "step_enqueued"]
         assert "process_id" in entries[0]
+        assert "host_id" in entries[0]
         trace_file.unlink()
 
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -288,10 +288,12 @@ def test_workflow_trace(tmp_path):
     workflow_id = entries[0]["workflow_id"]
     instance_id = entries[0]["workflow_instance_id"]
     process_id = entries[0]["process_id"]
+    host_id = entries[0]["host_id"]
     for e in entries:
         assert e["workflow_id"] == workflow_id
         assert e["workflow_instance_id"] == instance_id
         assert e["process_id"] == process_id
+        assert e["host_id"] == host_id
         assert "timestamp" in e
 
 
@@ -320,10 +322,12 @@ def test_trace_with_conditions(tmp_path):
     wf_id = events[0]["workflow_id"]
     inst_id = events[0]["workflow_instance_id"]
     proc_id = events[0]["process_id"]
+    host_id = events[0]["host_id"]
     for e in events:
         assert e["workflow_id"] == wf_id
         assert e["workflow_instance_id"] == inst_id
         assert e["process_id"] == proc_id
+        assert e["host_id"] == host_id
         assert "timestamp" in e
 
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -287,9 +287,11 @@ def test_workflow_trace(tmp_path):
     assert entries[5]["step"] == "B"
     workflow_id = entries[0]["workflow_id"]
     instance_id = entries[0]["workflow_instance_id"]
+    process_id = entries[0]["process_id"]
     for e in entries:
         assert e["workflow_id"] == workflow_id
         assert e["workflow_instance_id"] == instance_id
+        assert e["process_id"] == process_id
         assert "timestamp" in e
 
 
@@ -317,9 +319,11 @@ def test_trace_with_conditions(tmp_path):
     assert any(e.get("step") == "B2" and e["event"] == "step_finished" and e["skipped"] for e in events)
     wf_id = events[0]["workflow_id"]
     inst_id = events[0]["workflow_instance_id"]
+    proc_id = events[0]["process_id"]
     for e in events:
         assert e["workflow_id"] == wf_id
         assert e["workflow_instance_id"] == inst_id
+        assert e["process_id"] == proc_id
         assert "timestamp" in e
 
 


### PR DESCRIPTION
## Summary
- include `process_id` when recording trace events
- check for `process_id` in trace-related tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68605e1f56048332a16fa5dcd60e47d6