### PR TITLE
Compute execution groups automatically

### DIFF
--- a/examples/async_parallel_math_workflow.py
+++ b/examples/async_parallel_math_workflow.py
@@ -15,7 +15,7 @@ add = AsyncAddTask()
 
 class AsyncMultiplyBy2(AsyncTask):
     def __init__(self) -> None:
-        super().__init__(execution_group=1)
+        super().__init__()
 
     async def run_step_async(self, value: Computed[int] = Depends(add)) -> int:
         await asyncio.sleep(0.1)
@@ -24,7 +24,7 @@ class AsyncMultiplyBy2(AsyncTask):
 
 class AsyncMultiplyBy3(AsyncTask):
     def __init__(self) -> None:
-        super().__init__(execution_group=1)
+        super().__init__()
 
     async def run_step_async(self, value: Computed[int] = Depends(add)) -> int:
         await asyncio.sleep(0.1)
@@ -36,7 +36,7 @@ class AsyncJoinTask(AsyncTask):
     mul3 = AsyncMultiplyBy3()
 
     def __init__(self) -> None:
-        super().__init__(execution_group=2)
+        super().__init__()
 
     async def run_step_async(
         self,

--- a/examples/parallel_math_workflow.py
+++ b/examples/parallel_math_workflow.py
@@ -11,19 +11,17 @@ class AddTask(Task):
 add = AddTask()
 
 
-
 class MultiplyBy2(Task):
     def __init__(self) -> None:
-        super().__init__(execution_group=1)
+        super().__init__()
 
     def run_step(self, value: Computed[int] = Depends(add)) -> int:
         return value * 2
 
 
-
 class MultiplyBy3(Task):
     def __init__(self) -> None:
-        super().__init__(execution_group=1)
+        super().__init__()
 
     def run_step(self, value: Computed[int] = Depends(add)) -> int:
         return value * 3
@@ -34,7 +32,7 @@ class JoinTask(Task):
     mul3 = MultiplyBy3()
 
     def __init__(self) -> None:
-        super().__init__(execution_group=2)
+        super().__init__()
 
     def run_step(
         self,

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -365,16 +365,17 @@ def test_execution_groups_order() -> None:
     log: list[str] = []
 
     class Rec(Task):
-        def __init__(self, label: str, *, group: int) -> None:
-            super().__init__(execution_group=group)
+        def __init__(self, label: str) -> None:
+            super().__init__()
             self.label = label
 
         def run_step(self, setup_res: Any) -> None:  # pragma: no cover - simple
             log.append(self.label)
 
-    s1 = Rec("s1", group=1)
-    s2 = Rec("s2", group=0)
-    wf = Workflow(outputs=[s1, s2])
+    s1 = Rec("s1")
+    s2 = Rec("s2")
+    s2 >> s1
+    wf = Workflow(outputs=[s1])
     wf.run(execution_engine=ProcessEngine())
 
     assert log == ["s2", "s1"]


### PR DESCRIPTION
## Summary
- stop exposing `execution_group` in task constructors
- compute execution order in `Workflow`
- update examples and tests

## Testing
- `ruff format examples/parallel_math_workflow.py examples/async_parallel_math_workflow.py fuseline/workflow.py tests/test_workflow.py`
- `ruff check examples/parallel_math_workflow.py examples/async_parallel_math_workflow.py fuseline/workflow.py tests/test_workflow.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68610482ba388332adeb02a5cc44fa50