### PR TITLE
Remove redundant init methods

### DIFF
--- a/examples/async_parallel_math_workflow.py
+++ b/examples/async_parallel_math_workflow.py
@@ -14,18 +14,12 @@ add = AsyncAddTask()
 
 
 class AsyncMultiplyBy2(AsyncTask):
-    def __init__(self) -> None:
-        super().__init__()
-
     async def run_step_async(self, value: Computed[int] = Depends(add)) -> int:
         await asyncio.sleep(0.1)
         return value * 2
 
 
 class AsyncMultiplyBy3(AsyncTask):
-    def __init__(self) -> None:
-        super().__init__()
-
     async def run_step_async(self, value: Computed[int] = Depends(add)) -> int:
         await asyncio.sleep(0.1)
         return value * 3
@@ -34,9 +28,6 @@ class AsyncMultiplyBy3(AsyncTask):
 class AsyncJoinTask(AsyncTask):
     mul2 = AsyncMultiplyBy2()
     mul3 = AsyncMultiplyBy3()
-
-    def __init__(self) -> None:
-        super().__init__()
 
     async def run_step_async(
         self,

--- a/examples/parallel_math_workflow.py
+++ b/examples/parallel_math_workflow.py
@@ -12,17 +12,11 @@ add = AddTask()
 
 
 class MultiplyBy2(Task):
-    def __init__(self) -> None:
-        super().__init__()
-
     def run_step(self, value: Computed[int] = Depends(add)) -> int:
         return value * 2
 
 
 class MultiplyBy3(Task):
-    def __init__(self) -> None:
-        super().__init__()
-
     def run_step(self, value: Computed[int] = Depends(add)) -> int:
         return value * 3
 
@@ -30,9 +24,6 @@ class MultiplyBy3(Task):
 class JoinTask(Task):
     mul2 = MultiplyBy2()
     mul3 = MultiplyBy3()
-
-    def __init__(self) -> None:
-        super().__init__()
 
     def run_step(
         self,


### PR DESCRIPTION
## Summary
- remove empty `__init__` methods from async and regular parallel math examples

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6861211b46148332aa46a279b8e37492