### PR TITLE
Add pluggable runtime storage

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -15,6 +15,7 @@ The pages in this section describe Fuseline's major capabilities with short exam
 - [Retries with backoff](retries-with-backoff.md)
 - [Workflow export](workflow-export.md)
 - [Tracing](tracing.md)
+- [Runtime storage](runtime-storage.md)
 - [Function workflows](function-workflows.md)
 - [Branching actions](branching-actions.md)
 - [Fail-fast policy](fail-fast-policy.md)

--- a/docs/features/runtime-storage.md
+++ b/docs/features/runtime-storage.md
@@ -1,0 +1,13 @@
+---
+title: "Runtime storage"
+---
+
+Persist workflow state using `FileRuntimeStorage` so runs can be resumed or executed by multiple workers.
+
+```python
+from fuseline import Workflow, FileRuntimeStorage
+
+store = FileRuntimeStorage("runs")
+wf = Workflow(outputs=[...])
+wf.run(runtime_store=store)
+```

--- a/fuseline/__init__.py
+++ b/fuseline/__init__.py
@@ -27,6 +27,7 @@ from .engines import ProcessEngine
 from .exporters import YamlExporter
 from .interfaces import ExecutionEngine, Exporter, Tracer
 from .tracing import FileTracer
+from .storage import FileRuntimeStorage, RuntimeStorage
 from .typing import Computed, T
 from .workflow import (
     AsyncBatchTask,

--- a/fuseline/storage.py
+++ b/fuseline/storage.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+import os
+from abc import ABC, abstractmethod
+from typing import Iterable, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import for typing only
+    from .workflow import Status
+
+
+class RuntimeStorage(ABC):
+    """Interface for persisting workflow runtime state."""
+
+    @abstractmethod
+    def create_run(
+        self,
+        workflow_id: str,
+        instance_id: str,
+        steps: Iterable[str],
+    ) -> None:
+        """Initialize storage for a workflow run."""
+
+    @abstractmethod
+    def enqueue(self, workflow_id: str, instance_id: str, step_name: str) -> None:
+        """Mark *step_name* ready for execution."""
+
+    @abstractmethod
+    def fetch_next(self, workflow_id: str, instance_id: str) -> Optional[str]:
+        """Return the next ready step or ``None``."""
+
+    @abstractmethod
+    def set_state(
+        self,
+        workflow_id: str,
+        instance_id: str,
+        step_name: str,
+        state: "Status",
+    ) -> None:
+        """Persist the state of *step_name* for this run."""
+
+    @abstractmethod
+    def finalize_run(self, workflow_id: str, instance_id: str) -> None:
+        """Mark the run as finished."""
+
+
+class FileRuntimeStorage(RuntimeStorage):
+    """Store workflow runtime state in JSON files."""
+
+    def __init__(self, directory: str) -> None:
+        self.directory = directory
+        os.makedirs(directory, exist_ok=True)
+
+    def _path(self, workflow_id: str, instance_id: str) -> str:
+        return os.path.join(self.directory, f"{workflow_id}_{instance_id}.json")
+
+    def _load(self, workflow_id: str, instance_id: str) -> dict:
+        path = self._path(workflow_id, instance_id)
+        if not os.path.exists(path):
+            return {"queue": [], "states": {}}
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+
+    def _save(self, workflow_id: str, instance_id: str, data: dict) -> None:
+        with open(self._path(workflow_id, instance_id), "w", encoding="utf-8") as fh:
+            json.dump(data, fh)
+
+    def create_run(
+        self,
+        workflow_id: str,
+        instance_id: str,
+        steps: Iterable[str],
+    ) -> None:
+        from .workflow import Status
+
+        data = {"queue": list(steps), "states": {s: Status.PENDING.value for s in steps}}
+        self._save(workflow_id, instance_id, data)
+
+    def enqueue(self, workflow_id: str, instance_id: str, step_name: str) -> None:
+        from .workflow import Status
+
+        data = self._load(workflow_id, instance_id)
+        data.setdefault("queue", []).append(step_name)
+        data.setdefault("states", {}).setdefault(step_name, Status.PENDING.value)
+        self._save(workflow_id, instance_id, data)
+
+    def fetch_next(self, workflow_id: str, instance_id: str) -> Optional[str]:
+        data = self._load(workflow_id, instance_id)
+        if not data.get("queue"):
+            return None
+        step = data["queue"].pop(0)
+        self._save(workflow_id, instance_id, data)
+        return step
+
+    def set_state(
+        self,
+        workflow_id: str,
+        instance_id: str,
+        step_name: str,
+        state: "Status",
+    ) -> None:
+        from .workflow import Status
+
+        data = self._load(workflow_id, instance_id)
+        data.setdefault("states", {})[step_name] = state.value
+        self._save(workflow_id, instance_id, data)
+
+    def finalize_run(self, workflow_id: str, instance_id: str) -> None:
+        path = self._path(workflow_id, instance_id)
+        if os.path.exists(path):
+            data = self._load(workflow_id, instance_id)
+            data["finished"] = True
+            self._save(workflow_id, instance_id, data)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+
+from fuseline import Workflow
+from fuseline.storage import FileRuntimeStorage
+from fuseline.workflow import Task
+
+
+class SimpleTask(Task):
+    def __init__(self, label: str) -> None:
+        super().__init__()
+        self.label = label
+
+    def run_step(self, setup_res):
+        print(self.label)
+        return None
+
+
+def test_file_runtime_storage(tmp_path: Path) -> None:
+    s1 = SimpleTask("a")
+    s2 = SimpleTask("b")
+    s1 >> s2
+    store = FileRuntimeStorage(tmp_path.as_posix())
+    wf = Workflow(outputs=[s2])
+    wf.run(runtime_store=store)
+    files = list(tmp_path.iterdir())
+    assert files
+    data = json.loads(files[0].read_text())
+    assert data["finished"] is True
+    assert len(data["states"]) == 2
+    assert set(data["states"].values()) == {"SUCCEEDED"}


### PR DESCRIPTION
## Summary
- create `RuntimeStorage` interface with file-based implementation
- hook runtime storage into workflow execution
- expose storage classes from package root
- document runtime storage feature
- test file storage functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687672d658d08332977068427b566f20