### PR TITLE
Introduce policy abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ light/dark palette toggle.
 | **Parallel execution** | `PoolEngine` executes independent branches concurrently |
 | **Conditional dependencies** | Attach `Condition` functions to `Depends` for branch logic |
 | **Retries with backoff** | Tasks accept `max_retries` and `wait` to retry on failure |
+| **Policies** | Attach `Policy` objects to customise retries and other behaviour |
 | **Workflow export** | Serialize graphs to YAML with `Workflow.export` and `YamlExporter` |
 | **Tracing** | Record execution events using `FileTracer` |
 | **Runtime storage** | Persist workflow state so multiple workers can resume runs |

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -19,4 +19,5 @@ The pages in this section describe Fuseline's major capabilities with short exam
 - [Function workflows](function-workflows.md)
 - [Branching actions](branching-actions.md)
 - [Fail-fast policy](fail-fast-policy.md)
+- [Policies](../for-developers/policies.md)
 - [AND/OR joins](and-or-joins.md)

--- a/docs/for-developers/policies.md
+++ b/docs/for-developers/policies.md
@@ -2,36 +2,41 @@
 title: "Policies"
 ---
 
-Fuseline tasks expose simple reliability controls.
+Fuseline exposes a pluggable *policy* system. Policies attach to steps or
+workflows and modify how they run.
 
 ### Retries and backoff
 
-`Task` and `AsyncTask` accept `max_retries` and `wait` arguments. When a
-step raises an exception, it will be retried until `max_retries` is
-exhausted. The optional `wait` value sleeps between attempts.
+`RetryPolicy` controls how many times a step is retried. `Task` and
+`AsyncTask` automatically include a policy configured via the
+`max_retries` and `wait` arguments.
 
-Retries happen inside the task's private `_exec` method.  If a retry is
-needed the task logs the error and waits before running again.  You may
-subclass `Task` to implement custom backoff strategies or additional
-recovery logic.
+```python
+from fuseline import Task, Workflow
+from fuseline.policies import RetryPolicy
+
+class Flaky(Task):
+    def run_step(self) -> None:
+        raise RuntimeError("boom")
+
+step = Flaky()
+step.policies.append(RetryPolicy(max_retries=3, wait=1))
+Workflow(outputs=[step]).run()
+```
+
+Custom policies can subclass `StepPolicy` and override the hooks to
+implement additional behaviour.
 
 ### Fail-fast
 
 If any step fails after exhausting retries, downstream steps are marked
-`CANCELLED` and the workflow state becomes `FAILED`.
-
-Individual steps control this behaviour via the `max_retries` argument;
-set it to ``0`` to disable retries entirely.  A workflow stops as soon
-as any step reaches the `FAILED` state after exhausting its retries.
-Custom engines may choose to implement alternative fail-fast semantics.
+`CANCELLED` and the workflow state becomes `FAILED`. Set `max_retries=0`
+to disable retries. Custom engines may implement alternative semantics.
 
 ### Common questions
 
-- How do I override retry logic?  Subclass `Task` and implement
-  `exec_fallback` to customize what happens after the final failure.
+- How do I override retry logic?  Subclass `StepPolicy`.
 - Can I pause a workflow?  Persist state using `RuntimeStorage` and resume
   with `ProcessEngine`.
-- Can I change timeouts or other limits?  You can extend `Task` and raise
-  your own exceptions in `run_step` when conditions are not met.  The
-  engine will treat those like any other failure and apply the retry
-  policy.
+- Can I change timeouts or other limits?  Implement a custom policy and
+  raise exceptions in `run_step` when limits are hit.

--- a/examples/README.md
+++ b/examples/README.md
@@ -74,3 +74,7 @@ has one path forward the action name defaults to ``"default"``.
 
 Runs a simple workflow while recording the order of executed steps to
 ``trace_workflow.trace`` using the ``trace`` argument on ``Workflow``.
+
+## policy_workflow.py
+
+Demonstrates attaching a ``RetryPolicy`` to a step.

--- a/examples/policy_workflow.py
+++ b/examples/policy_workflow.py
@@ -1,0 +1,21 @@
+from fuseline import Task, Workflow
+from fuseline.policies import RetryPolicy
+
+
+class SometimesFails(Task):
+    def __init__(self) -> None:
+        super().__init__(max_retries=1)
+        self.attempts = 0
+
+    def run_step(self) -> None:
+        self.attempts += 1
+        if self.attempts < 2:
+            raise RuntimeError("boom")
+
+
+fail = SometimesFails()
+# attach a custom policy
+fail.policies.append(RetryPolicy(max_retries=3, wait=0.5))
+
+wf = Workflow(outputs=[fail])
+wf.run()

--- a/fuseline/policies.py
+++ b/fuseline/policies.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""Policy interfaces for workflow behaviour.
+
+These abstractions allow steps and workflows to customise execution
+semantics without hardcoding logic in the core classes.  Individual
+policies implement hooks which are invoked by :class:`Step` and
+:class:`Workflow` during execution.
+"""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Dict, Type
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from .workflow import Step
+
+
+# registry for serializable policies
+_POLICY_REGISTRY: Dict[str, Type["Policy"]] = {}
+
+
+class Policy(abc.ABC):
+    """Base class for all policies."""
+
+    name = "policy"
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        if hasattr(cls, "name"):
+            _POLICY_REGISTRY[cls.name] = cls
+
+    def to_config(self) -> Dict[str, Any]:
+        """Return a serialisable representation."""
+        return {}
+
+    @classmethod
+    def from_config(cls, cfg: Dict[str, Any]) -> "Policy":
+        return cls(**cfg)  # type: ignore[arg-type]
+
+
+class FailureAction(str, Enum):
+    """Decision returned when a step fails."""
+
+    RETRY = "retry"
+    FAIL = "fail"
+    SKIP = "skip"
+
+
+@dataclass
+class FailureDecision:
+    """Outcome from :meth:`StepPolicy.on_failure`."""
+
+    action: FailureAction
+    delay: float = 0.0
+
+
+class StepPolicy(Policy):
+    """Policy applied to individual steps."""
+
+    def on_start(self, step: "Step") -> None:
+        pass
+
+    def on_success(self, step: "Step", result: Any) -> None:
+        pass
+
+    def on_failure(self, step: "Step", exc: Exception, attempt: int) -> FailureDecision | None:
+        return None
+
+
+class RetryPolicy(StepPolicy):
+    """Simple retry policy replicating ``Task`` behaviour."""
+
+    name = "retry"
+
+    def __init__(self, max_retries: int = 1, wait: float = 0.0) -> None:
+        self.max_retries = max_retries
+        self.wait = wait
+
+    def to_config(self) -> Dict[str, Any]:
+        return {"max_retries": self.max_retries, "wait": self.wait}
+
+    def on_failure(self, step: "Step", exc: Exception, attempt: int) -> FailureDecision:
+        if attempt < self.max_retries - 1:
+            return FailureDecision(FailureAction.RETRY, self.wait)
+        return FailureDecision(FailureAction.FAIL)
+
+
+__all__ = [
+    "_POLICY_REGISTRY",
+    "FailureAction",
+    "FailureDecision",
+    "Policy",
+    "RetryPolicy",
+    "StepPolicy",
+]


### PR DESCRIPTION
## Summary
- add a `Policy` system with `RetryPolicy`
- plug policies into `Step`, `Task` and `Workflow`
- serialize policies in workflow schemas
- document the new policy interface and add example

## Testing
- `ruff check fuseline examples/policy_workflow.py`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879071fbab483328bbd028c1c6450fa