### PR TITLE
Refactor broker endpoints to use typed responses

### DIFF
--- a/docs/for-developers/broker-api.md
+++ b/docs/for-developers/broker-api.md
@@ -4,7 +4,9 @@ title: "Broker API"
 
 The broker stores workflow definitions and tracks running instances.
 Workers communicate with it over HTTP using a small set of endpoints.
-Each step handed to a worker is represented by a `StepAssignment` object
+Each endpoint uses typed dataclasses from ``robyn.types`` for request
+payloads and responses so the API surface is self-documenting.  Steps
+handed to a worker are represented by a `StepAssignment` object
 containing the workflow identifiers, the payload needed to run the task
 and a timeout deadline.
 

--- a/docs/for-developers/broker-api.md
+++ b/docs/for-developers/broker-api.md
@@ -35,6 +35,23 @@ The actual implementation also ensures any raw JSON payload is converted
 to the dataclass at runtime so type hints remain accurate even if the
 framework does not deserialize the body for us.
 
+Query parameters can be typed in the same way using ``QueryParams``. For
+example, a keep-alive endpoint might look like:
+
+```python
+from dataclasses import dataclass
+from robyn.types import QueryParams, JSONResponse
+
+@dataclass
+class KeepAliveQuery(QueryParams):
+    worker_id: str
+
+@app.post("/worker/keep-alive")
+def keep_alive(query_params: KeepAliveQuery) -> JSONResponse:
+    broker.keep_alive(query_params.worker_id)
+    return JSONResponse()
+```
+
 ## Repository endpoints
 
 ### Register repository

--- a/docs/for-developers/broker-api.md
+++ b/docs/for-developers/broker-api.md
@@ -10,6 +10,24 @@ handed to a worker are represented by a `StepAssignment` object
 containing the workflow identifiers, the payload needed to run the task
 and a timeout deadline.
 
+For example, the worker registration endpoint expects a ``Body`` model and
+returns a ``JSONResponse`` dataclass:
+
+```python
+from robyn.types import Body, JSONResponse
+
+class WorkerRegisterBody(Body):
+    workflows: list[dict[str, Any]]
+
+class WorkerIdResponse(JSONResponse):
+    worker_id: str
+
+@app.post("/worker/register")
+def register_worker(body: WorkerRegisterBody) -> WorkerIdResponse:
+    wid = broker.register_worker(body.workflows)
+    return WorkerIdResponse(worker_id=wid)
+```
+
 ## Repository endpoints
 
 ### Register repository

--- a/docs/for-developers/broker-api.md
+++ b/docs/for-developers/broker-api.md
@@ -17,7 +17,7 @@ returns a ``JSONResponse`` dataclass:
 from robyn.types import Body, JSONResponse
 
 class WorkerRegisterBody(Body):
-    workflows: list[dict[str, Any]]
+    workflows: list[dict[str, object]]
 
 class WorkerIdResponse(JSONResponse):
     worker_id: str

--- a/docs/for-developers/broker-api.md
+++ b/docs/for-developers/broker-api.md
@@ -17,7 +17,7 @@ returns a ``JSONResponse`` dataclass:
 from robyn.types import Body, JSONResponse
 
 class WorkerRegisterBody(Body):
-    workflows: list[dict[str, object]]
+    workflows: list[dict]
 
 class WorkerIdResponse(JSONResponse):
     worker_id: str

--- a/docs/for-developers/broker-api.md
+++ b/docs/for-developers/broker-api.md
@@ -31,6 +31,10 @@ def register_worker(body: WorkerRegisterBody) -> WorkerIdResponse:
     return WorkerIdResponse(worker_id=wid)
 ```
 
+The actual implementation also ensures any raw JSON payload is converted
+to the dataclass at runtime so type hints remain accurate even if the
+framework does not deserialize the body for us.
+
 ## Repository endpoints
 
 ### Register repository

--- a/docs/for-developers/broker-api.md
+++ b/docs/for-developers/broker-api.md
@@ -14,11 +14,14 @@ For example, the worker registration endpoint expects a ``Body`` model and
 returns a ``JSONResponse`` dataclass:
 
 ```python
+from dataclasses import dataclass
 from robyn.types import Body, JSONResponse
 
+@dataclass
 class WorkerRegisterBody(Body):
     workflows: list[dict]
 
+@dataclass
 class WorkerIdResponse(JSONResponse):
     worker_id: str
 

--- a/fuseline/broker/http.py
+++ b/fuseline/broker/http.py
@@ -8,7 +8,7 @@ except Exception:  # pragma: no cover - optional
         return None
 
 
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from typing import Any, Iterable
 
 try:
@@ -81,26 +81,32 @@ __all__ = [
 # Typed request and response models
 # ---------------------------------------------------------------------------
 
+@dataclass
 class WorkerRegisterBody(Body):
     workflows: list[dict]
 
 
+@dataclass
 class WorkerIdResponse(JSONResponse):
     worker_id: str
 
 
+@dataclass
 class KeepAliveQuery(QueryParams):
     worker_id: str
 
 
+@dataclass
 class StatusResponse(JSONResponse):
     status: str
 
 
+@dataclass
 class WorkersResponse(JSONResponse):
     workers: list[dict]
 
 
+@dataclass
 class RepositoryRegisterBody(Body):
     name: str
     url: str
@@ -108,23 +114,28 @@ class RepositoryRegisterBody(Body):
     credentials: dict[str, str]
 
 
+@dataclass
 class RepositoryResponse(JSONResponse):
     repository: dict | list[dict] | None
 
 
+@dataclass
 class DispatchBody(Body):
     workflow: dict
     inputs: dict | None = None
 
 
+@dataclass
 class DispatchResponse(JSONResponse):
     instance_id: str
 
 
+@dataclass
 class StepQuery(QueryParams):
     worker_id: str
 
 
+@dataclass
 class StepBody(Body):
     workflow_id: str
     instance_id: str
@@ -133,10 +144,12 @@ class StepBody(Body):
     result: dict | list | str | int | float | bool | None
 
 
+@dataclass
 class StepResponse(JSONResponse):
     step: dict | None
 
 
+@dataclass
 class WorkflowsResponse(JSONResponse):
     workflows: list[dict]
 

--- a/fuseline/broker/http.py
+++ b/fuseline/broker/http.py
@@ -94,6 +94,13 @@ def _coerce_dataclass(data: Any, model: Type[T]) -> T:
         data = data.decode()
     if isinstance(data, str):
         data = json.loads(data or "{}")
+    if not isinstance(data, dict):
+        fields = getattr(model, "__dataclass_fields__", {})
+        if len(fields) == 1:
+            field = next(iter(fields))
+            data = {field: data}
+        else:
+            raise TypeError(f"Cannot convert {type(data)} to {model}")
     return model(**data)
 
 

--- a/fuseline/broker/http.py
+++ b/fuseline/broker/http.py
@@ -11,7 +11,7 @@ except Exception:  # pragma: no cover - optional
 
 
 import json
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from typing import Any, Iterable
 
 try:

--- a/fuseline/broker/http.py
+++ b/fuseline/broker/http.py
@@ -262,6 +262,7 @@ def register_worker_routes(app: Robyn, broker: Broker) -> None:
 
     @app.post("/worker/keep-alive", openapi_tags=["worker"])
     def keep_alive(query_params: KeepAliveQuery) -> JSONResponse:  # pragma: no cover - integration
+        query_params = _coerce_dataclass(query_params, KeepAliveQuery)
         handle_keep_alive(broker, query_params.worker_id)
         return JSONResponse()
 
@@ -288,6 +289,7 @@ def register_repository_routes(app: Robyn, broker: Broker) -> None:
     @app.get("/repository", openapi_tags=["repository"])
     def get_repo(query_params: RepositoryQuery) -> RepositoryResponse:
         # pragma: no cover - integration
+        query_params = _coerce_dataclass(query_params, RepositoryQuery)
         name = query_params.name
         page = query_params.page
         if name:
@@ -314,11 +316,13 @@ def register_workflow_routes(app: Robyn, broker: Broker) -> None:
 
     @app.get("/workflow/step", openapi_tags=["workflow"])
     def get_step(query_params: StepQuery) -> StepResponse:  # pragma: no cover - integration
+        query_params = _coerce_dataclass(query_params, StepQuery)
         data = handle_get_step(broker, query_params.worker_id)
         return StepResponse(step=data)
 
     @app.post("/workflow/step", openapi_tags=["workflow"])
     def report_step(query_params: StepQuery, body: StepBody) -> JSONResponse:  # pragma: no cover - integration
+        query_params = _coerce_dataclass(query_params, StepQuery)
         body = _coerce_dataclass(body, StepBody)
         handle_report_step(broker, query_params.worker_id, asdict(body))
         return JSONResponse()

--- a/fuseline/broker/http.py
+++ b/fuseline/broker/http.py
@@ -83,7 +83,7 @@ __all__ = [
 
 @dataclass
 class WorkerRegisterBody(Body):
-    workflows: list[dict[str, object]]
+    workflows: list[dict[str, Any]]
 
 
 @dataclass
@@ -103,7 +103,7 @@ class StatusResponse(JSONResponse):
 
 @dataclass
 class WorkersResponse(JSONResponse):
-    workers: list[dict[str, object]]
+    workers: list[dict[str, Any]]
 
 
 @dataclass
@@ -116,13 +116,13 @@ class RepositoryRegisterBody(Body):
 
 @dataclass
 class RepositoryResponse(JSONResponse):
-    repository: dict[str, object] | list[dict[str, object]] | None
+    repository: dict[str, Any] | list[dict[str, Any]] | None
 
 
 @dataclass
 class DispatchBody(Body):
-    workflow: dict[str, object]
-    inputs: dict[str, object] | None = None
+    workflow: dict[str, Any]
+    inputs: dict[str, Any] | None = None
 
 
 @dataclass
@@ -141,17 +141,17 @@ class StepBody(Body):
     instance_id: str
     step_name: str
     state: Status
-    result: object
+    result: Any
 
 
 @dataclass
 class StepResponse(JSONResponse):
-    step: dict[str, object] | None
+    step: dict[str, Any] | None
 
 
 @dataclass
 class WorkflowsResponse(JSONResponse):
-    workflows: list[dict[str, object]]
+    workflows: list[dict[str, Any]]
 
 
 def handle_register_worker(broker: Broker, payload: Iterable[dict[str, Any]]) -> str:

--- a/fuseline/broker/http.py
+++ b/fuseline/broker/http.py
@@ -83,7 +83,7 @@ __all__ = [
 
 @dataclass
 class WorkerRegisterBody(Body):
-    workflows: list[dict[str, object]]
+    workflows: list[dict]
 
 
 @dataclass
@@ -103,7 +103,7 @@ class StatusResponse(JSONResponse):
 
 @dataclass
 class WorkersResponse(JSONResponse):
-    workers: list[dict[str, object]]
+    workers: list[dict]
 
 
 @dataclass
@@ -116,13 +116,13 @@ class RepositoryRegisterBody(Body):
 
 @dataclass
 class RepositoryResponse(JSONResponse):
-    repository: dict[str, object] | list[dict[str, object]] | None
+    repository: dict | list[dict] | None
 
 
 @dataclass
 class DispatchBody(Body):
-    workflow: dict[str, object]
-    inputs: dict[str, object] | None = None
+    workflow: dict
+    inputs: dict | None = None
 
 
 @dataclass
@@ -141,17 +141,17 @@ class StepBody(Body):
     instance_id: str
     step_name: str
     state: Status
-    result: object
+    result: dict | list | str | int | float | bool | None
 
 
 @dataclass
 class StepResponse(JSONResponse):
-    step: dict[str, object] | None
+    step: dict | None
 
 
 @dataclass
 class WorkflowsResponse(JSONResponse):
-    workflows: list[dict[str, object]]
+    workflows: list[dict]
 
 
 def handle_register_worker(broker: Broker, payload: Iterable[dict[str, Any]]) -> str:

--- a/fuseline/broker/http.py
+++ b/fuseline/broker/http.py
@@ -14,7 +14,7 @@ from typing import Any, Iterable
 try:
     from robyn import Response, Robyn
     from robyn import status_codes as robyn_status_codes
-    from robyn.robyn import QueryParams
+    from robyn.robyn import QueryParams, Request
     from robyn.types import Body, JSONResponse
 except Exception:  # pragma: no cover - optional
 
@@ -219,7 +219,8 @@ def register_worker_routes(app: Robyn, broker: Broker) -> None:
     """Register worker-related routes on *app*."""
 
     @app.post("/worker/register", openapi_tags=["worker"])
-    async def register(request, body: WorkerRegisterBody) -> WorkerIdResponse:  # pragma: no cover - integration
+    async def register(request: Request, body: WorkerRegisterBody) -> WorkerIdResponse:
+        # pragma: no cover - integration
         wid = handle_register_worker(broker, body.workflows)
         return WorkerIdResponse(worker_id=wid)
 
@@ -248,7 +249,8 @@ def register_repository_routes(app: Robyn, broker: Broker) -> None:
         return JSONResponse()
 
     @app.get("/repository", openapi_tags=["repository"])
-    async def get_repo(request, query_params: QueryParams) -> RepositoryResponse:  # pragma: no cover - integration
+    async def get_repo(request: Request, query_params: QueryParams) -> RepositoryResponse:
+        # pragma: no cover - integration
         name = query_params.get("name")  # type: ignore[attr-defined]
         page = int(query_params.get("page", "1"))  # type: ignore[attr-defined]
         if name:

--- a/fuseline/broker/http.py
+++ b/fuseline/broker/http.py
@@ -17,6 +17,8 @@ from typing import Any, Iterable
 try:
     from robyn import Response, Robyn
     from robyn import status_codes as robyn_status_codes
+    from robyn.types import Body, JSONResponse
+    from robyn.robyn import QueryParams
 except Exception:  # pragma: no cover - optional
 
     class StatusCodes:  # pragma: no cover - minimal stub
@@ -41,6 +43,15 @@ except Exception:  # pragma: no cover - optional
 
     class Robyn:  # pragma: no cover - dummy stub for type checkers
         def __init__(self, *args: _Any, **kwargs: _Any) -> None: ...
+
+    class Body:  # pragma: no cover - stub for typed requests
+        pass
+
+    class JSONResponse:  # pragma: no cover - stub for typed responses
+        pass
+
+    class QueryParams:  # pragma: no cover - stub for typed query parameters
+        pass
 
 
 from ..workflow import WorkflowSchema
@@ -67,6 +78,83 @@ __all__ = [
     "register_worker_routes",
     "register_workflow_routes",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Typed request and response models
+# ---------------------------------------------------------------------------
+
+@dataclass
+class WorkerRegisterBody(Body):
+    workflows: list[dict[str, Any]]
+
+
+@dataclass
+class WorkerIdResponse(JSONResponse):
+    worker_id: str
+
+
+@dataclass
+class KeepAliveQuery(QueryParams):
+    worker_id: str
+
+
+@dataclass
+class StatusResponse(JSONResponse):
+    status: str
+
+
+@dataclass
+class WorkersResponse(JSONResponse):
+    workers: list[dict[str, Any]]
+
+
+@dataclass
+class RepositoryRegisterBody(Body):
+    name: str
+    url: str
+    workflows: list[str]
+    credentials: dict[str, str]
+
+
+@dataclass
+class RepositoryResponse(JSONResponse):
+    repository: dict[str, Any] | list[dict[str, Any]] | None
+
+
+@dataclass
+class DispatchBody(Body):
+    workflow: dict[str, Any]
+    inputs: dict[str, Any] | None = None
+
+
+@dataclass
+class DispatchResponse(JSONResponse):
+    instance_id: str
+
+
+@dataclass
+class StepQuery(QueryParams):
+    worker_id: str
+
+
+@dataclass
+class StepBody(Body):
+    workflow_id: str
+    instance_id: str
+    step_name: str
+    state: Any
+    result: Any
+
+
+@dataclass
+class StepResponse(JSONResponse):
+    step: dict[str, Any] | None
+
+
+@dataclass
+class WorkflowsResponse(JSONResponse):
+    workflows: list[dict[str, Any]]
 
 
 def handle_register_worker(broker: Broker, payload: Iterable[dict[str, Any]]) -> str:
@@ -134,103 +222,74 @@ def register_worker_routes(app: Robyn, broker: Broker) -> None:
     """Register worker-related routes on *app*."""
 
     @app.post("/worker/register", openapi_tags=["worker"])
-    async def register(request):  # pragma: no cover - integration
-        payload = json.loads(request.body)
-        wid = handle_register_worker(broker, payload)
-        return Response(robyn_status_codes.HTTP_200_OK, {}, wid)
+    async def register(request, body: WorkerRegisterBody) -> WorkerIdResponse:  # pragma: no cover - integration
+        wid = handle_register_worker(broker, body.workflows)
+        return WorkerIdResponse(worker_id=wid)
 
     @app.post("/worker/keep-alive", openapi_tags=["worker"])
-    async def keep_alive(request):  # pragma: no cover - integration
-        wid = request.query_params.get("worker_id", None)
-        handle_keep_alive(broker, wid)
-        return Response(robyn_status_codes.HTTP_204_NO_CONTENT, {}, "")
+    async def keep_alive(query_params: KeepAliveQuery) -> JSONResponse:  # pragma: no cover - integration
+        handle_keep_alive(broker, query_params.worker_id)
+        return JSONResponse()
 
     @app.get("/workers", openapi_tags=["worker"])
-    async def workers(request):  # pragma: no cover - integration
+    async def workers() -> WorkersResponse:  # pragma: no cover - integration
         data = handle_get_workers(broker)
-        return Response(
-            robyn_status_codes.HTTP_200_OK,
-            {"Content-Type": "application/json"},
-            json.dumps(data),
-        )
+        return WorkersResponse(workers=data)
 
     @app.get("/status", openapi_tags=["system"])
-    async def status(request):  # pragma: no cover - integration
+    async def status() -> StatusResponse:  # pragma: no cover - integration
         data = handle_status(broker)
-        return Response(
-            robyn_status_codes.HTTP_200_OK,
-            {"Content-Type": "application/json"},
-            json.dumps(data),
-        )
+        return StatusResponse(status=data["status"])
 
 
 def register_repository_routes(app: Robyn, broker: Broker) -> None:
     """Register repository endpoints."""
 
     @app.post("/repository/register", openapi_tags=["repository"])
-    async def register_repo(request):  # pragma: no cover - integration
-        payload = json.loads(request.body)
-        handle_register_repository(broker, payload)
-        return Response(robyn_status_codes.HTTP_204_NO_CONTENT, {}, "")
+    async def register_repo(body: RepositoryRegisterBody) -> JSONResponse:  # pragma: no cover - integration
+        handle_register_repository(broker, asdict(body))
+        return JSONResponse()
 
     @app.get("/repository", openapi_tags=["repository"])
-    async def get_repo(request):  # pragma: no cover - integration
-        name = request.query_params.get("name", None)
-        page = int(request.query_params.get("page", "1"))
+    async def get_repo(request, query_params: QueryParams) -> RepositoryResponse:  # pragma: no cover - integration
+        name = query_params.get("name")  # type: ignore[attr-defined]
+        page = int(query_params.get("page", "1"))  # type: ignore[attr-defined]
         if name:
             data = handle_get_repository(broker, name)
             if data is None:
-                return Response(robyn_status_codes.HTTP_404_NOT_FOUND, {}, "")
+                return RepositoryResponse(repository=None)
             payload = data
         else:
-            page_size = int(request.query_params.get("page_size", "50"))
+            page_size = int(query_params.get("page_size", "50"))  # type: ignore[attr-defined]
             repos = handle_list_repositories(broker, page, page_size)
             if not repos and page > 1:
-                return Response(robyn_status_codes.HTTP_404_NOT_FOUND, {}, "")
+                return RepositoryResponse(repository=None)
             payload = repos
-        return Response(
-            robyn_status_codes.HTTP_200_OK,
-            {"Content-Type": "application/json"},
-            json.dumps(payload),
-        )
+        return RepositoryResponse(repository=payload)
 
 
 def register_workflow_routes(app: Robyn, broker: Broker) -> None:
     """Register workflow endpoints."""
 
     @app.post("/workflow/dispatch", openapi_tags=["workflow"])
-    async def dispatch(request):  # pragma: no cover - integration
-        payload = json.loads(request.body)
-        instance = handle_dispatch_workflow(broker, payload)
-        return Response(robyn_status_codes.HTTP_200_OK, {}, instance)
+    async def dispatch(body: DispatchBody) -> DispatchResponse:  # pragma: no cover - integration
+        instance = handle_dispatch_workflow(broker, asdict(body))
+        return DispatchResponse(instance_id=instance)
 
     @app.get("/workflow/step", openapi_tags=["workflow"])
-    async def get_step(request):  # pragma: no cover - integration
-        wid = request.query_params.get("worker_id", None)
-        data = handle_get_step(broker, wid)
-        if data is None:
-            return Response(robyn_status_codes.HTTP_204_NO_CONTENT, {}, "")
-        return Response(
-            robyn_status_codes.HTTP_200_OK,
-            {"Content-Type": "application/json"},
-            json.dumps(data),
-        )
+    async def get_step(query_params: StepQuery) -> StepResponse:  # pragma: no cover - integration
+        data = handle_get_step(broker, query_params.worker_id)
+        return StepResponse(step=data)
 
     @app.post("/workflow/step", openapi_tags=["workflow"])
-    async def report_step(request):  # pragma: no cover - integration
-        wid = request.query_params.get("worker_id", None)
-        payload = json.loads(request.body)
-        handle_report_step(broker, wid, payload)
-        return Response(robyn_status_codes.HTTP_204_NO_CONTENT, {}, "")
+    async def report_step(query_params: StepQuery, body: StepBody) -> JSONResponse:  # pragma: no cover - integration
+        handle_report_step(broker, query_params.worker_id, asdict(body))
+        return JSONResponse()
 
     @app.get("/workflows", openapi_tags=["workflow"])
-    async def list_wfs(request):  # pragma: no cover - integration
+    async def list_wfs() -> WorkflowsResponse:  # pragma: no cover - integration
         data = handle_list_workflows(broker)
-        return Response(
-            robyn_status_codes.HTTP_200_OK,
-            {"Content-Type": "application/json"},
-            json.dumps(data),
-        )
+        return WorkflowsResponse(workflows=data)
 
 
 def register_routes(app: Robyn, broker: Broker) -> None:

--- a/fuseline/broker/http.py
+++ b/fuseline/broker/http.py
@@ -51,7 +51,7 @@ except Exception:  # pragma: no cover - optional
         pass
 
 
-from ..workflow import WorkflowSchema
+from ..workflow import Status, WorkflowSchema
 from . import Broker, PostgresBroker, RepositoryInfo, StepReport
 from .openapi import OPENAPI_SPEC, SWAGGER_HTML
 
@@ -83,7 +83,7 @@ __all__ = [
 
 @dataclass
 class WorkerRegisterBody(Body):
-    workflows: list[dict[str, Any]]
+    workflows: list[dict[str, object]]
 
 
 @dataclass
@@ -103,7 +103,7 @@ class StatusResponse(JSONResponse):
 
 @dataclass
 class WorkersResponse(JSONResponse):
-    workers: list[dict[str, Any]]
+    workers: list[dict[str, object]]
 
 
 @dataclass
@@ -116,13 +116,13 @@ class RepositoryRegisterBody(Body):
 
 @dataclass
 class RepositoryResponse(JSONResponse):
-    repository: dict[str, Any] | list[dict[str, Any]] | None
+    repository: dict[str, object] | list[dict[str, object]] | None
 
 
 @dataclass
 class DispatchBody(Body):
-    workflow: dict[str, Any]
-    inputs: dict[str, Any] | None = None
+    workflow: dict[str, object]
+    inputs: dict[str, object] | None = None
 
 
 @dataclass
@@ -140,18 +140,18 @@ class StepBody(Body):
     workflow_id: str
     instance_id: str
     step_name: str
-    state: Any
-    result: Any
+    state: Status
+    result: object
 
 
 @dataclass
 class StepResponse(JSONResponse):
-    step: dict[str, Any] | None
+    step: dict[str, object] | None
 
 
 @dataclass
 class WorkflowsResponse(JSONResponse):
-    workflows: list[dict[str, Any]]
+    workflows: list[dict[str, object]]
 
 
 def handle_register_worker(broker: Broker, payload: Iterable[dict[str, Any]]) -> str:

--- a/fuseline/broker/http.py
+++ b/fuseline/broker/http.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 
 try:  # optional dependency
@@ -10,15 +8,14 @@ except Exception:  # pragma: no cover - optional
         return None
 
 
-import json
 from dataclasses import asdict, dataclass
 from typing import Any, Iterable
 
 try:
     from robyn import Response, Robyn
     from robyn import status_codes as robyn_status_codes
-    from robyn.types import Body, JSONResponse
     from robyn.robyn import QueryParams
+    from robyn.types import Body, JSONResponse
 except Exception:  # pragma: no cover - optional
 
     class StatusCodes:  # pragma: no cover - minimal stub

--- a/fuseline/broker/http.py
+++ b/fuseline/broker/http.py
@@ -83,7 +83,7 @@ __all__ = [
 
 @dataclass
 class WorkerRegisterBody(Body):
-    workflows: list[dict[str, Any]]
+    workflows: list[dict[str, object]]
 
 
 @dataclass
@@ -103,7 +103,7 @@ class StatusResponse(JSONResponse):
 
 @dataclass
 class WorkersResponse(JSONResponse):
-    workers: list[dict[str, Any]]
+    workers: list[dict[str, object]]
 
 
 @dataclass
@@ -116,13 +116,13 @@ class RepositoryRegisterBody(Body):
 
 @dataclass
 class RepositoryResponse(JSONResponse):
-    repository: dict[str, Any] | list[dict[str, Any]] | None
+    repository: dict[str, object] | list[dict[str, object]] | None
 
 
 @dataclass
 class DispatchBody(Body):
-    workflow: dict[str, Any]
-    inputs: dict[str, Any] | None = None
+    workflow: dict[str, object]
+    inputs: dict[str, object] | None = None
 
 
 @dataclass
@@ -141,17 +141,17 @@ class StepBody(Body):
     instance_id: str
     step_name: str
     state: Status
-    result: Any
+    result: object
 
 
 @dataclass
 class StepResponse(JSONResponse):
-    step: dict[str, Any] | None
+    step: dict[str, object] | None
 
 
 @dataclass
 class WorkflowsResponse(JSONResponse):
-    workflows: list[dict[str, Any]]
+    workflows: list[dict[str, object]]
 
 
 def handle_register_worker(broker: Broker, payload: Iterable[dict[str, Any]]) -> str:


### PR DESCRIPTION
## Summary
- replace plain Response returns with `JSONResponse` dataclasses
- define Body and QueryParams models for request payloads
- update endpoints to return typed responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68852b38f280833281d1fb3f949da37e